### PR TITLE
Add v6 spec

### DIFF
--- a/FORMAT.md
+++ b/FORMAT.md
@@ -38,7 +38,7 @@ original patch output filename. Useful if a single game can generate two
 different patches.
 
 
-### ROM-based games
+#### ROM-based games using "DeltaPatch" (bsdiff)
 
 JSON also contains
 * `"base_checksum": "[hex string of md5 of vanilla file]"`
@@ -48,6 +48,29 @@ ZIP file also contains
 * `delta.bsdiff4` file that is the diff between original and randomized ROM
 
 The bsdiff should ideally be stored (not compressed).
+
+
+#### ROM-based games using zpf
+
+ZIP file also contains
+* a `.zpf` file that is to be applied using ZPF tool
+
+
+### v6
+
+JSON may contain `"procedure": ...` to descibe how to apply the patch.
+* If procedure is absent or null, behavior is like in v5.
+* If procedure is a string `"custom"` that means the steps neccessary to
+  apply the patch are defined per game and not specified here.
+  This is a custom APPatch, neither APDeltaPatch nor APProcedurePatch.
+* Otherwise procedure has to be an array of tuples `[step, args]`,
+  where args is an array, i.e. `[["apply_bsdiff4", ["delta.bsdiff4"]]]`.
+  This means it's an
+  [APProcedurePatch](https://github.com/ArchipelagoMW/Archipelago/pull/2536)
+
+JSON may contain `"custom_version"` that is an integer to differentiate between
+multiple custom handlers for the same game. For now, it is up to the handler to
+use or ignore `custom_version`.
 
 
 ## Version detection


### PR DESCRIPTION
Now that more games use custom APPatch (and we have proper inheritance) and now that APProcedurePatch is on the horizon, we should define `procedure` to mark the patch file as such. Note that `compatible_version` can and should stay at `5` for APDeltaPatch and Z5 patches for backwards compat during rollout.

This suggestion is slightly incompatible to the current [APProcedurePatch PR](https://github.com/ArchipelagoMW/Archipelago/pull/2536) in that it allows procedure to be absent.

If procedure is defined, and it is not `[["apply_bsdiff4", ["delta.bsdiff4"]]]`, then `compatible_version` has to be set to `6` to properly error out when trying to use an outdated patcher.

The "custom" APPatch specifically uses the same `"procedure"` field as APProcedurePatch to make it fail if we were to try using "custom" in a APPP implementation.


If no procedure is defined, nor can it be detected as v5 DeltaPatch nor as v5 ZPF patch, it's actually an APContainer, not an APPath, i.e. there is no "apply" or "patch" functionality. Factorio mods are one example of this.